### PR TITLE
Slack notifier

### DIFF
--- a/site-cookbooks/factorio/attributes/api.rb
+++ b/site-cookbooks/factorio/attributes/api.rb
@@ -1,2 +1,3 @@
 default.factorio.api.install_location = '/opt/factorio-api'
 default.factorio.api.socket_location = '/tmp/factorio-api.sock'
+default.factorio.api.slack_webhook = false

--- a/site-cookbooks/factorio/files/default/app/Gemfile
+++ b/site-cookbooks/factorio/files/default/app/Gemfile
@@ -5,6 +5,7 @@ gem 'thin'
 gem 'sinatra'
 
 # for the join and leave notifier
+gem 'tins', '~> 1.6.0' # dependency of file-tail that wants ruby 2 sometimes
 gem 'file-tail'
 gem 'slack-notifier'
 

--- a/site-cookbooks/factorio/files/default/app/Gemfile
+++ b/site-cookbooks/factorio/files/default/app/Gemfile
@@ -1,7 +1,12 @@
 source 'https://rubygems.org'
 
+# for the web APIs
 gem 'thin'
 gem 'sinatra'
+
+# for the join and leave notifier
+gem 'file-tail'
+gem 'slack-notifier'
 
 group :development do
   gem 'rerun'

--- a/site-cookbooks/factorio/files/default/app/Gemfile.lock
+++ b/site-cookbooks/factorio/files/default/app/Gemfile.lock
@@ -5,6 +5,8 @@ GEM
     daemons (1.2.3)
     eventmachine (1.2.0.1)
     ffi (1.9.10)
+    file-tail (1.1.1)
+      tins (~> 1.0)
     listen (3.0.6)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
@@ -25,20 +27,24 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    slack-notifier (1.5.1)
     slop (3.6.0)
     thin (1.6.4)
       daemons (~> 1.0, >= 1.0.9)
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     tilt (2.0.2)
+    tins (1.10.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  file-tail
   pry
   rerun
   sinatra
+  slack-notifier
   thin
 
 BUNDLED WITH

--- a/site-cookbooks/factorio/files/default/app/Gemfile.lock
+++ b/site-cookbooks/factorio/files/default/app/Gemfile.lock
@@ -7,9 +7,10 @@ GEM
     ffi (1.9.10)
     file-tail (1.1.1)
       tins (~> 1.0)
-    listen (3.0.6)
+    listen (3.1.2)
       rb-fsevent (>= 0.9.3)
       rb-inotify (>= 0.9.7)
+      ruby_dep (~> 1.1)
     method_source (0.8.2)
     pry (0.10.3)
       coderay (~> 1.1.0)
@@ -23,6 +24,7 @@ GEM
       ffi (>= 0.5.0)
     rerun (0.11.0)
       listen (~> 3.0)
+    ruby_dep (1.1.0)
     sinatra (1.4.7)
       rack (~> 1.5)
       rack-protection (~> 1.4)
@@ -34,7 +36,7 @@ GEM
       eventmachine (~> 1.0, >= 1.0.4)
       rack (~> 1.0)
     tilt (2.0.2)
-    tins (1.10.1)
+    tins (1.6.0)
 
 PLATFORMS
   ruby
@@ -46,6 +48,7 @@ DEPENDENCIES
   sinatra
   slack-notifier
   thin
+  tins (~> 1.6.0)
 
 BUNDLED WITH
    1.11.2

--- a/site-cookbooks/factorio/files/default/app/lib/factorio.rb
+++ b/site-cookbooks/factorio/files/default/app/lib/factorio.rb
@@ -26,6 +26,10 @@ class Factorio
     @server ||= Factorio::ServerService.new(self)
   end
 
+  def players
+    @players ||= Factorio::PlayerService.new(self)
+  end
+
   ### locations
   def storage_location
     @sl ||= Pathname.new(config['save_location'])
@@ -50,3 +54,4 @@ require_relative './factorio/base_service'
 require_relative './factorio/save_service'
 require_relative './factorio/server_service'
 require_relative './factorio/mod_service'
+require_relative './factorio/players_service'

--- a/site-cookbooks/factorio/files/default/app/lib/factorio/players_service.rb
+++ b/site-cookbooks/factorio/files/default/app/lib/factorio/players_service.rb
@@ -154,7 +154,7 @@ class Factorio
 
     def notify(string)
       # this goes in our log
-      puts "NOTIFY: #{string}"
+      STDERR.puts "NOTIFY: #{string}"
       # post to slack
       if @webhook
         @webhook.ping(string)
@@ -177,7 +177,7 @@ class Factorio
         log.tail do |line|
           event = LogLine.from_line(line)
           if event.is_info? && event.info_event
-            puts "EVENT #{event}"
+            STDERR.puts "EVENT #{event}"
             handle_event(event)
           end
         end

--- a/site-cookbooks/factorio/files/default/app/lib/factorio/players_service.rb
+++ b/site-cookbooks/factorio/files/default/app/lib/factorio/players_service.rb
@@ -1,0 +1,188 @@
+require 'time'
+require 'slack-notifier'
+require 'file-tail'
+
+class Factorio
+  class PlayerService < BaseService
+    class LogLine < Struct.new("LogLone", :logged_at, :factorio_time, :words)
+      TIME_FORMAT = '%a %b %d at %I:%M:%S.%6N %P'.freeze
+      FACTORIO_ZERO = '0.000'.freeze
+      INFO = 'Info'.freeze
+
+      # connection events
+      # 1. adding peer(ID) address(IP) sending connectionAttempt(true)
+      # 2. networkTick(SOME_INT) adding peer(ID) success(true)
+      # 3. lists the peerInfo for each connected peer
+      # -> Received peer info for peer(ID) username(UNSERNAME)
+      # -> at this point we can emit the notification for the newly added peer(ID)
+
+      # disconnect events
+      # 1. networkTick(SOME_INT) mapTick(SOME_INT) removing peer(ID) dropout(BOOLEAN)
+      # -> we can look up the name for peer(ID)
+
+      def self.parens(name)
+        name = name.to_s
+        "#{name}\\((?<#{name}>\\w+)\\)"
+      end
+
+      EVENTS = {
+        :adding_peer => /#{parens(:networkTick)} adding #{parens(:peer)} #{parens(:success)}/,
+        :peer_info => /Received peer info for #{parens(:peer)} #{parens(:username)}/,
+        :removing_peer => /#{parens(:networkTick)} #{parens(:mapTick)} removing #{parens(:peer)} #{parens(:dropout)}/,
+      }.freeze
+
+      def self.from_line(line)
+        exact_time, factorio_time, *words = line.split(/\s+/)
+        self.new(exact_time, factorio_time, words)
+      rescue ArgumentError
+        # TODO: log error?
+        return nil
+      end
+
+      def self.load_file(path)
+        log_lines = []
+        File.readlines(path).each do |line|
+          event = from_line(line)
+          if event.is_info?
+            if event.info_event
+              log_lines << event
+            end
+          end
+        end
+        log_lines
+      end
+
+      def initialize(logged_at, factorio_time, words)
+        super(logged_at, factorio_time, words)
+        time()
+      end
+
+      def is_factorio?
+        factorio_time.to_f != 0.0 || factorio_time == FACTORIO_ZERO
+      end
+
+      def is_info?
+        is_factorio? && words[0] == INFO
+      end
+
+      def info_event
+        info_text = words[2..-1].join(' ')
+        EVENTS.each do |name, regex|
+          capture = regex.match(info_text)
+          return name, capture if capture
+        end
+        nil
+      end
+
+      # the CPP source file in factorio where the log message was emitted
+      def log_source
+        if is_info?
+          file, line = words[1].split(':')
+          return [file, line.to_i]
+        else
+          nil
+        end
+      end
+
+      def time
+        @time ||= Time.parse(logged_at)
+      rescue
+        nil
+      end
+
+      def to_s
+        body = words.join(' ')
+        if is_info?
+          event, data = info_event
+          if event
+            hsh = {}
+            data.names.each { |n| hsh[n.to_sym] = data[n] }
+            body = "event #{event.inspect} >> #{hsh.inspect}"
+          end
+        end
+        "[ #{time.strftime(TIME_FORMAT)} ] #{factorio_time} - #{body}"
+      end
+    end # end class LogLine
+
+    class Peer
+      attr_accessor :username, :connected, :notified_connect, :notified_disconnect
+      def initialize
+        @connected = nil
+        @username = nil
+      end
+    end
+
+    attr_reader :peers
+
+    def initialize(factorio)
+      super(factorio)
+      @peers = Hash.new { |h, k| h[k] = Peer.new }
+      if factorio.config && factorio.config['api']['slack_webhook']
+        @webhook = Slack::Notifier.new(factorio.config['api']['slack_webhook'])
+      end
+    end
+
+    def handle_event(log_line)
+      event, data = log_line.info_event
+      peer_id = data[:peer]
+      case event
+      when :peer_info
+        peers[peer_id].username = data[:username]
+      when :adding_peer
+        peers[peer_id].connected = true
+      when :removing_peer
+        peers[peer_id].connected = false
+      end
+      send_notifications
+    end
+
+    def send_notifications
+      peers.each do |peer_id, peer|
+        # connect
+        if peer.connected == true && peer.username && !peer.notified_connect
+          peer.notified_connect = true
+          notify("user #{peer.username} connected")
+        end
+
+        # disconnect
+        if peer.connected == false && peer.username && !peer.notified_disconnect
+          peer.notified_disconnect = true
+          notify("user #{peer.username} disconnected")
+        end
+      end
+    end
+
+    def notify(string)
+      # this goes in our log
+      puts "NOTIFY: #{string}"
+      # post to slack
+      if @webhook
+        @webhook.ping(string)
+      end
+    end
+
+    def events_in_file(filename)
+      log_events = LogLine.load_file(filename)
+      log_events.each do |event|
+        handle_event(event)
+      end
+    end
+
+    def tail_file(filename)
+      File::Tail::Logfile.open(filename) do |log|
+        log.tail do |line|
+          event = LogLine.from_line(line)
+          if event.is_info? && event.info_event
+            puts "EVENT #{event}"
+            handle_event(event)
+          end
+        end
+      end
+    end
+
+    # depends on the server service
+    def log_file
+      factorio.server.log_file
+    end
+  end
+end

--- a/site-cookbooks/factorio/files/default/app/lib/factorio/players_service.rb
+++ b/site-cookbooks/factorio/files/default/app/lib/factorio/players_service.rb
@@ -170,6 +170,10 @@ class Factorio
 
     def tail_file(filename)
       File::Tail::Logfile.open(filename) do |log|
+        # be responsive
+        log.interval = 1
+        # go to end of file
+        log.backward(0)
         log.tail do |line|
           event = LogLine.from_line(line)
           if event.is_info? && event.info_event

--- a/site-cookbooks/factorio/files/default/app/notifier.rb
+++ b/site-cookbooks/factorio/files/default/app/notifier.rb
@@ -1,0 +1,10 @@
+require 'yaml'
+require_relative './lib/factorio'
+
+APP_DIR = File.dirname(__FILE__)
+CONFIG_PATH = ENV['CONFIG'] || File.join(APP_DIR, 'config.yml')
+CONFIG = YAML::load(File.read(CONFIG_PATH))
+factorio = Factorio.new(CONFIG)
+
+LOG_FILE = '/var/log/factorio/current'
+factorio.players.tail_file(log_file)

--- a/site-cookbooks/factorio/files/default/app/notifier.rb
+++ b/site-cookbooks/factorio/files/default/app/notifier.rb
@@ -7,4 +7,4 @@ CONFIG = YAML::load(File.read(CONFIG_PATH))
 factorio = Factorio.new(CONFIG)
 
 LOG_FILE = '/var/log/factorio/current'
-factorio.players.tail_file(log_file)
+factorio.players.tail_file(LOG_FILE)

--- a/site-cookbooks/factorio/recipes/api.rb
+++ b/site-cookbooks/factorio/recipes/api.rb
@@ -41,6 +41,10 @@ runit_service 'factorio-api' do
   default_logger true
 end
 
+runit_service 'factorio-notifier' do
+  default_logger true
+end
+
 the_location = "http://unix:#{node.factorio.api.socket_location}:"
 
 # set up reverse proxy for our factorio server

--- a/site-cookbooks/factorio/recipes/api.rb
+++ b/site-cookbooks/factorio/recipes/api.rb
@@ -12,6 +12,7 @@ remote_directory node.factorio.api.install_location do
   group 'root'
   mode '0755'
   notifies :restart, "runit_service[factorio-api]", :delayed
+  notifies :restart, "runit_service[factorio-notifier]", :delayed
 end
 
 file 'config' do

--- a/site-cookbooks/factorio/templates/default/sv-factorio-notifier-run.erb
+++ b/site-cookbooks/factorio/templates/default/sv-factorio-notifier-run.erb
@@ -1,0 +1,6 @@
+#!/bin/bash -ex
+exec 2>&1
+
+cd <%= node.factorio.api.install_location %>
+exec chpst -u factorio \
+     bundle exec ruby ./notifier.rb


### PR DESCRIPTION
Notify a slack webhook when users connect to the Factorio server.

This is implemented by tailing and parsing the Factorio log file. Notifications should be sent only once, and will not be re-sent if the notification service restarts.

@sjzhu @philihp
